### PR TITLE
Improve numeric limit declarations

### DIFF
--- a/Eolib/Data/EONumericLimits.php
+++ b/Eolib/Data/EONumericLimits.php
@@ -17,25 +17,25 @@ namespace Eolib\Data;
  *
  * @var int
  */
-define('EOLIB_CHAR_MAX', 253);
+const EO_CHAR_MAX = 253;
 
 /**
  * The maximum value that can be represented by two bytes (unsigned).
  *
  * @var int
  */
-define('EOLIB_SHORT_MAX', EOLIB_CHAR_MAX * EOLIB_CHAR_MAX);
+const EO_SHORT_MAX = CHAR_MAX * CHAR_MAX;
 
 /**
  * The maximum value that can be represented by three bytes (unsigned).
  *
  * @var int
  */
-define('EOLIB_THREE_MAX', EOLIB_CHAR_MAX * EOLIB_CHAR_MAX * EOLIB_CHAR_MAX);
+const EO_THREE_MAX = CHAR_MAX * CHAR_MAX * CHAR_MAX;
 
 /**
  * The maximum value that can be represented by four bytes (unsigned).
  *
  * @var int
  */
-define('EOLIB_INT_MAX', EOLIB_CHAR_MAX * EOLIB_CHAR_MAX * EOLIB_CHAR_MAX * EOLIB_CHAR_MAX);
+const EO_INT_MAX = CHAR_MAX * CHAR_MAX * CHAR_MAX * CHAR_MAX;

--- a/Eolib/Data/EOWriter.php
+++ b/Eolib/Data/EOWriter.php
@@ -56,12 +56,12 @@ class EoWriter
     /**
      * Adds an encoded character to the data array as a 1-byte integer.
      *
-     * @param int $number The character code to add (must be within EOLIB_CHAR_MAX - 1).
+     * @param int $number The character code to add (must be within EO_CHAR_MAX - 1).
      * @throws \ValueError If the number is out of the allowable range.
      */
     public function addChar(int $number): void
     {
-        $this->checkNumberSize($number, EOLIB_CHAR_MAX - 1);
+        $this->checkNumberSize($number, EO_CHAR_MAX - 1);
         $numberBytes = NumberEncodingUtils::encodeNumber($number);
         $this->addBytesWithLength($numberBytes, 1);
     }
@@ -69,12 +69,12 @@ class EoWriter
     /**
      * Adds an encoded short integer to the data array as a 2-byte integer.
      *
-     * @param int $number The short to add (must be within EOLIB_SHORT_MAX - 1).
+     * @param int $number The short to add (must be within EO_SHORT_MAX - 1).
      * @throws \ValueError If the number is out of the allowable range.
      */
     public function addShort(int $number): void
     {
-        $this->checkNumberSize($number, EOLIB_SHORT_MAX - 1);
+        $this->checkNumberSize($number, EO_SHORT_MAX - 1);
         $numberBytes = NumberEncodingUtils::encodeNumber($number);
         $this->addBytesWithLength($numberBytes, 2);
     }
@@ -82,12 +82,12 @@ class EoWriter
     /**
      * Adds an encoded integer to the data array as a 3-byte integer.
      *
-     * @param int $number The integer to add (must be within EOLIB_THREE_MAX - 1).
+     * @param int $number The integer to add (must be within EO_THREE_MAX - 1).
      * @throws \ValueError If the number is out of the allowable range.
      */
     public function addThree(int $number): void
     {
-        $this->checkNumberSize($number, EOLIB_THREE_MAX - 1);
+        $this->checkNumberSize($number, EO_THREE_MAX - 1);
         $numberBytes = NumberEncodingUtils::encodeNumber($number);
         $this->addBytesWithLength($numberBytes, 3);
     }
@@ -95,12 +95,12 @@ class EoWriter
     /**
      * Adds an encoded integer to the data array as a 4-byte integer.
      *
-     * @param int $number The integer to add (must be within EOLIB_INT_MAX - 1).
+     * @param int $number The integer to add (must be within EO_INT_MAX - 1).
      * @throws \ValueError If the number is out of the allowable range.
      */
     public function addInt(int $number): void
     {
-        $this->checkNumberSize($number, EOLIB_INT_MAX - 1);
+        $this->checkNumberSize($number, EO_INT_MAX - 1);
         $numberBytes = NumberEncodingUtils::encodeNumber($number);
         $this->addBytesWithLength($numberBytes, 4);
     }

--- a/Eolib/Data/NumberEncodingUtils.php
+++ b/Eolib/Data/NumberEncodingUtils.php
@@ -24,21 +24,21 @@ class NumberEncodingUtils {
      */
     public static function encodeNumber(int $number): array {
         $d = 0xFE;
-        if ($number >= EOLIB_THREE_MAX) {
-            $d = intdiv($number, EOLIB_THREE_MAX) + 1;
-            $number %= EOLIB_THREE_MAX;
+        if ($number >= EO_THREE_MAX) {
+            $d = intdiv($number, EO_THREE_MAX) + 1;
+            $number %= EO_THREE_MAX;
         }
 
         $c = 0xFE;
-        if ($number >= EOLIB_SHORT_MAX) {
-            $c = intdiv($number, EOLIB_SHORT_MAX) + 1;
-            $number %= EOLIB_SHORT_MAX;
+        if ($number >= EO_SHORT_MAX) {
+            $c = intdiv($number, EO_SHORT_MAX) + 1;
+            $number %= EO_SHORT_MAX;
         }
 
         $b = 0xFE;
-        if ($number >= EOLIB_CHAR_MAX) {
-            $b = intdiv($number, EOLIB_CHAR_MAX) + 1;
-            $number %= EOLIB_CHAR_MAX;
+        if ($number >= EO_CHAR_MAX) {
+            $b = intdiv($number, EO_CHAR_MAX) + 1;
+            $number %= EO_CHAR_MAX;
         }
 
         $a = $number + 1;
@@ -75,13 +75,13 @@ class NumberEncodingUtils {
                     $result += $value;
                     break;
                 case 1:
-                    $result += EOLIB_CHAR_MAX * $value;
+                    $result += EO_CHAR_MAX * $value;
                     break;
                 case 2:
-                    $result += EOLIB_SHORT_MAX * $value;
+                    $result += EO_SHORT_MAX * $value;
                     break;
                 case 3:
-                    $result += EOLIB_THREE_MAX * $value;
+                    $result += EO_THREE_MAX * $value;
                     break;
             }
         }


### PR DESCRIPTION
This PR changes `EONumericLimits` to:
- use `const` instead of `define` for declaring the constants
  - this scopes the constants to the `Eolib\Data` namespace
- use prefix `EO` instead of `EOLIB` in constant names
  - shorter and appropriate since these constants describe aspects of EO data types